### PR TITLE
✅Add basic gas optimizations

### DIFF
--- a/src/EdgelessDeposit.sol
+++ b/src/EdgelessDeposit.sol
@@ -19,6 +19,7 @@ contract EdgelessDeposit is Ownable2StepUpgradeable {
     WrappedToken public wrappedEth;
     IL1ERC20Bridge public l1standardBridge;
     StakingManager public stakingManager;
+    uint256[50] private __gap;
 
     event DepositEth(address indexed to, address indexed from, uint256 EthAmount, uint256 mintAmount);
     event MintWrappedEth(address indexed to, uint256 amount);

--- a/src/StakingManager.sol
+++ b/src/StakingManager.sol
@@ -19,6 +19,7 @@ contract StakingManager is Ownable2StepUpgradeable {
     address public depositor;
     bool public autoStake;
     address public constant ETH_ADDRESS = address(0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE);
+    uint256[50] private __gap;
 
     event Stake(address indexed asset, uint256 amount);
     event Withdraw(address indexed asset, uint256 amount);

--- a/src/strategies/EthStrategy.sol
+++ b/src/strategies/EthStrategy.sol
@@ -73,8 +73,8 @@ contract EthStrategy is IStakingStrategy, Ownable2StepUpgradeable {
         onlyOwner
         returns (uint256[] memory requestIds)
     {
-        uint256 total = 0;
-        for (uint256 i = 0; i < amounts.length; i++) {
+        uint256 total;
+        for (uint256 i; i < amounts.length; ++i) {
             total += amounts[i];
         }
         LIDO.approve(address(LIDO_WITHDRAWAL_ERC721), total);

--- a/src/strategies/EthStrategy.sol
+++ b/src/strategies/EthStrategy.sol
@@ -9,6 +9,7 @@ import { LIDO, LIDO_WITHDRAWAL_ERC721 } from "../Constants.sol";
 contract EthStrategy is IStakingStrategy, Ownable2StepUpgradeable {
     address public stakingManager;
     bool public autoStake;
+    uint256[50] private __gap;
 
     event EthStaked(uint256 amount);
     event EthWithdrawn(uint256 amount);


### PR DESCRIPTION
- [H-1] LIDO withdrawals won't work
Description: When you claim a LIDO withdrawal, you are exchanging your STETH for ETH again.
Response: Previously Fixed

- [H-2] Removing strategies will fail most of the time
Description: When you claim a LIDO withdrawal, you are exchanging your STETH for ETH again. If you go to LIDOs code
Response: Previously Fixed

- [M-1] UUPSUpgradeable is missing
Description:
On the Readme says that - **Edgeless Deposit Contract**: This contract is UUPS Upgradeable by the owner. the Edgeless Deposit Contract is UUPS upgradeable, though it does not implement the UUPSUpgradeable import from OZ.
Response: Check the `deployment/` scripts for how we use proxies, there is no need to import UUPSUpgradable here iirc

- [M-2] Attacker can take over the implementation contract
Description:
When using UUPS proxies, it is mandatory that the implementation contract can't be left un-initialized becuase and attacker could take over the contract and either upgrade or selfdestruct.
Response: I don't think this is necessary either, check the deployment scripts. I'm fairly confident that after initialization nothing will happen, can you provide or describe a POC of how this attack would work?

- [M-3] Corrupted upgradeability pattern 
Description:
The contracts EdgelessDeposit, StakingManager, and EthStrategy , do not have gap storage implemented.
Thus, adding new storage variables to any of these inherited contracts can potentially overwrite the beginning of the storage layout of the child contract. causing critical misbehaviors in the system.
Response: Unlikely for this to be an issue, but added `gap` to EthStrategy, EdgelessDeposit, and StakingManager

- [L-1] Event state can be incorrect
I think this is a low risk to the point where it isn't worth addressing

- [GAS]
Fixed

